### PR TITLE
RMSRCBUILD-115: Upgrade to NUnit 3

### DIFF
--- a/.nuget/packages.config
+++ b/.nuget/packages.config
@@ -4,6 +4,6 @@
   <package id="DependDB.BuildProcessor.NuGetPreProcessor" version="2.0.0" />
   <package id="MSBuild.Extension.Pack" version="1.5.0" />
   <package id="NuGet.CommandLine" version="3.5.0" />
-  <package id="NUnit.Runners" version="2.6.3" />
+  <package id="NUnit.ConsoleRunner" version="3.11.1" targetFramework="net45" />
   <package id="Remotion.BuildTools.MSBuildTasks" version="1.0.5827.25795" />
 </packages>

--- a/Build/Remotion.build
+++ b/Build/Remotion.build
@@ -25,7 +25,7 @@
     <ExtensionTasksPath>$(MSBuildExtensionPackPath)</ExtensionTasksPath>
     <DependDBBuildProcessorToolPath Condition="'$(NuGetToolPath)' == ''">$(PackagesDirectory)DependDB.BuildProcessor.2.0.0\tools\</DependDBBuildProcessorToolPath>
     <DependDBNuGetPreProcessorToolPath Condition="'$(NuGetToolPath)' == ''">$(PackagesDirectory)DependDB.BuildProcessor.NuGetPreProcessor.2.0.0\tools\</DependDBNuGetPreProcessorToolPath>
-    <NUnitToolPath Condition="'$(NUnitToolPath)' == ''">$(PackagesDirectory)NUnit.Runners.2.6.3\tools\</NUnitToolPath>
+    <NUnitToolPath Condition="'$(NUnitToolPath)' == ''">$(PackagesDirectory)NUnit.ConsoleRunner.3.11.1\tools\</NUnitToolPath>
     <NuGetToolPath Condition="'$(NuGetToolPath)' == ''">$(PackagesDirectory)NuGet.CommandLine.2.8.2\tools\</NuGetToolPath>
     <NuGetForMSBuildPath Condition="'$(NuGetForMSBuildPath)' == ''">$(PackagesDirectory)NuGet.for.MSBuild.1.4.3\build\</NuGetForMSBuildPath>
     <RemotionBuildTasksPath Condition="'$(RemotionBuildTasksPath)' == ''">$(PackagesDirectory)Remotion.BuildTools.MSBuildTasks.1.0.5827.25795\tools\</RemotionBuildTasksPath>

--- a/BuildScript.UnitTests/BuildScript.UnitTests.csproj
+++ b/BuildScript.UnitTests/BuildScript.UnitTests.csproj
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\NUnit.3.12.0\build\NUnit.props" Condition="Exists('..\packages\NUnit.3.12.0\build\NUnit.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -34,8 +35,8 @@
   <ItemGroup>
     <Reference Include="Microsoft.Build.Framework" />
     <Reference Include="Microsoft.Build.Utilities.v4.0" />
-    <Reference Include="nunit.framework, Version=2.6.2.12296, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77">
-      <HintPath>..\packages\NUnit.2.6.2\lib\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.12.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb">
+      <HintPath>..\packages\NUnit.3.12.0\lib\net45\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Rhino.Mocks, Version=3.6.0.0, Culture=neutral, PublicKeyToken=0b3305902db7183f">
@@ -61,6 +62,12 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105.The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\NUnit.3.12.0\build\NUnit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit.3.12.0\build\NUnit.props'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/BuildScript.UnitTests/packages.config
+++ b/BuildScript.UnitTests/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit" version="2.6.2" targetFramework="net45" />
+  <package id="NUnit" version="3.12.0" targetFramework="net47" />
   <package id="RhinoMocks" version="3.6.1" targetFramework="net45" />
 </packages>

--- a/BuildScript/BuildTargets/Testing.targets
+++ b/BuildScript/BuildTargets/Testing.targets
@@ -36,25 +36,19 @@
 
   <ItemGroup>
     <NumberOfTestFailuresPerProject Include="0"/>
-    <NumberOfTestErrorsPerProject Include="0"/>
   </ItemGroup>
 
   <!-- Main target; reporting only, calls RunTestsInternal for actual work -->
   <Target Name="RunTests" DependsOnTargets="CreateTestConfigurations;CreateLogDirectory;BuildTestProjects;LogRunTestsStartTime;RunTestsInternal">
     <Error Text="The property 'ConfigurationID' is not set." Condition="'$(ConfigurationID)' == ''" />
     <Error Text="ItemGroup 'NumberOfTestFailuresPerProject' is empty, but should contain test results!" Condition="@(NumberOfTestFailuresPerProject) == ''"/>
-    <Error Text="ItemGroup 'NumberOfTestErrorsPerProject' is empty, but should contain test results!" Condition="@(NumberOfTestErrorsPerProject) == ''"/>
-
     <MSBuild.ExtensionPack.Science.Maths TaskAction="Add" Numbers="@(NumberOfTestFailuresPerProject)">
       <Output PropertyName="_failures" TaskParameter="Result"/>
     </MSBuild.ExtensionPack.Science.Maths>
-    <MSBuild.ExtensionPack.Science.Maths TaskAction="Add" Numbers="@(NumberOfTestErrorsPerProject)">
-      <Output PropertyName="_errors" TaskParameter="Result"/>
-    </MSBuild.ExtensionPack.Science.Maths>
 
     <Error
-      Text="Running Unit-Tests failed because of $(_failures) failures and/or $(_errors) errors in: %0A@(FailedProjects->'%(Identity) (%(Platform)/%(DatabaseSystem)) with %(Failures) failures and %(Errors) errors','%0A')"
-      Condition="$(_failures) &gt; 0 or $(_errors) &gt; 0"/>
+      Text="Running Unit-Tests failed because of $(_failures) failures in: %0A@(FailedProjects->'%(Identity) (%(Platform)/%(DatabaseSystem)) with %(Failures) failures','%0A')"
+      Condition="$(_failures) &gt; 0"/>
 
     <PropertyGroup>
       <_timeTaken>$([System.DateTime]::UtcNow.Subtract($([System.DateTime]::Parse($(RunTestsStartTime)))).TotalMilliseconds.ToString(0))</_timeTaken>
@@ -83,8 +77,6 @@
     <Error Text="The property 'NoDB' is not set." Condition="'$(NoDB)' == ''"/>
     <Error Text="The property 'NoBrowser' is not set." Condition="'$(NoBrowser)' == ''"/>
     <Error Text="The property 'NUnitToolPath' is not set." Condition="'$(NUnitToolPath)' == ''"/>
-    <Error Text="The property 'NunitFolderPathWithDefaultConfiguration' is not set." Condition="'$(NunitFolderPathWithDefaultConfiguration)' == ''"/>
-    <Error Text="The property 'NunitFolderPathWithoutDotNet35Dependency' is not set." Condition="'$(NunitFolderPathWithoutDotNet35Dependency)' == ''"/>
 
     <MSBuild.ExtensionPack.Framework.MsBuildHelper TaskAction="GetItemCount" InputItems1="@(_testOutputFiles)">
       <Output TaskParameter="ItemCount" PropertyName="_testOutputFilesCount"/>
@@ -127,16 +119,39 @@
       <_mergedTestCategoriesToExclude>$(TestCategoriesToExclude.Replace(';', ',')),$(_excludeCategoriesInTestConfiguration)</_mergedTestCategoriesToExclude>
       <_mergedTestCategoriesToExclude>$(_mergedTestCategoriesToExclude.Trim(','))</_mergedTestCategoriesToExclude>
 
-      <_excludeCategoriesCallArgumentString></_excludeCategoriesCallArgumentString>
-      <_excludeCategoriesCallArgumentString Condition="'$(_mergedTestCategoriesToExclude)' != ''">/exclude=$(_mergedTestCategoriesToExclude)</_excludeCategoriesCallArgumentString>
-    </PropertyGroup>
-
-    <PropertyGroup>
       <_mergedTestCategoriesToInclude>$(TestCategoriesToInclude.Replace(';', ',')),$(_includeCategoriesInTestConfiguration)</_mergedTestCategoriesToInclude>
       <_mergedTestCategoriesToInclude>$(_mergedTestCategoriesToInclude.Trim(','))</_mergedTestCategoriesToInclude>
+    </PropertyGroup>
 
-      <_includeCategoriesCallArgumentString></_includeCategoriesCallArgumentString>
-      <_includeCategoriesCallArgumentString Condition="'$(_mergedTestCategoriesToInclude)' != ''">/include=$(_mergedTestCategoriesToInclude)</_includeCategoriesCallArgumentString>
+    <ItemGroup>
+      <_splitCategoriesToExclude Remove="@(_splitCategoriesToExclude)"/>
+      <_splitCategoriesToExclude Include="$(_mergedTestCategoriesToExclude.Split(','))"/>
+
+      <_splitCategoriesToInclude Remove="@(_splitCategoriesToInclude)"/>
+      <_splitCategoriesToInclude Include="$(_mergedTestCategoriesToInclude.Split(','))"/>
+
+      <_exludeFilters Remove="@(_exludeFilters)"/>
+      <_exludeFilters Include="cat != %(_splitCategoriesToExclude.Identity) "/>
+
+      <_inludeFilters Remove="@(_inludeFilters)"/>
+      <_inludeFilters Include="cat == %(_splitCategoriesToInclude.Identity) "/>
+    </ItemGroup>
+
+    <PropertyGroup>
+      <_excludeCategoriesCallArgumentString>@(_exludeFilters)</_excludeCategoriesCallArgumentString>
+      <_excludeCategoriesCallArgumentString>$(_excludeCategoriesCallArgumentString.Replace(";", " &amp;&amp; "))</_excludeCategoriesCallArgumentString>
+
+      <_includeCategoriesCallArgumentString>@(_inludeFilters)</_includeCategoriesCallArgumentString>
+      <_includeCategoriesCallArgumentString>$(_includeCategoriesCallArgumentString.Replace(";", " &amp;&amp; "))</_includeCategoriesCallArgumentString>
+    </PropertyGroup>
+
+    <!--  Output example: where "cat != ExcludeMe1 && cat != ExcludeMe2 && cat == IncludeMe"  -->
+    <PropertyGroup>
+      <_nunitTestFilter></_nunitTestFilter>
+      <_nunitTestFilter Condition="$(_mergedTestCategoriesToExclude)!='' And $(_mergedTestCategoriesToInclude)!=''">$(_excludeCategoriesCallArgumentString) &amp;&amp; $(_includeCategoriesCallArgumentString)</_nunitTestFilter>
+      <_nunitTestFilter Condition="$(_mergedTestCategoriesToExclude)!='' And $(_mergedTestCategoriesToInclude)==''">$(_excludeCategoriesCallArgumentString)</_nunitTestFilter>
+      <_nunitTestFilter Condition="$(_mergedTestCategoriesToExclude)=='' And $(_mergedTestCategoriesToInclude)!=''">$(_includeCategoriesCallArgumentString)</_nunitTestFilter>
+      <_nunitTestFilter Condition="$(_nunitTestFilter)!=''">--where "$(_nunitTestFilter)"</_nunitTestFilter>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -149,12 +164,16 @@
     </PropertyGroup>
 
     <PropertyGroup>
-      <_nunitRunnerFileName>nunit-console.exe</_nunitRunnerFileName>
-      <_nunitRunnerFileName Condition="$(_use32Bit) == 'True'">nunit-console-x86.exe</_nunitRunnerFileName>
-    </PropertyGroup>
-
-    <PropertyGroup>
-      <_nunitCallArgumentString>/nologo /noshadow $(_testAssemblyFullPath) $(_includeCategoriesCallArgumentString) $(_excludeCategoriesCallArgumentString) /framework=$(_targetRuntime) /xml=$(_testResultFile)</_nunitCallArgumentString>
+      <_nunitRunnerFileName>nunit3-console.exe</_nunitRunnerFileName>
+      <_use32BitArgument Condition="$(_use32Bit) == 'True'">--x86</_use32BitArgument>
+      <_nunitCallArgumentString> ^
+        $(_use32BitArgument) ^
+        $(_testAssemblyFullPath) ^
+        $(_nunitTestFilter) ^
+        --framework=$(_targetRuntime) ^
+        --result=$(_testResultFile) ^
+        --list-extensions
+      </_nunitCallArgumentString>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -167,7 +186,7 @@
 
     <!--If DockerDisabled, call Nunit Runner directly-->
     <Exec
-        Command="$(NunitFolderPathWithDefaultConfiguration)$(_nunitRunnerFileName) $(_nunitCallArgumentString)"
+        Command="$(_nunitRunnerFolderPath)$(_nunitRunnerFileName) $(_nunitCallArgumentString)"
         IgnoreExitCode="true"
         Condition="$(_dockerEnabled) == 'False'"/>
 
@@ -176,10 +195,10 @@
       <_dockerCommand>
 docker run ^
 --rm ^
---volume $(NunitFolderPathWithoutDotNet35Dependency):$(NunitFolderPathWithoutDotNet35Dependency) ^
+--volume $(_nunitRunnerFolderPath):$(_nunitRunnerFolderPath) ^
 --volume $(_testAssemblyDirectory):$(_testAssemblyDirectory) ^
 --volume $(LogDirectory):$(LogDirectory) ^
---entrypoint $(NunitFolderPathWithoutDotNet35Dependency)$(_nunitRunnerFileName) ^
+--entrypoint $(_nunitRunnerFolderPath)$(_nunitRunnerFileName) ^
 $(_dockerImageName) $(_nunitCallArgumentString)
       </_dockerCommand>
     </PropertyGroup>
@@ -201,22 +220,15 @@ $(_dockerImageName) $(_nunitCallArgumentString)
     <MSBuild.ExtensionPack.Xml.XmlFile
         TaskAction="ReadAttribute"
         File="$(_testResultFile)"
-        XPath="/test-results/test-suite/@time">
+        XPath="/test-run/test-suite/@duration">
       <Output TaskParameter="Value" PropertyName="_testTime" />
     </MSBuild.ExtensionPack.Xml.XmlFile>
 
     <MSBuild.ExtensionPack.Xml.XmlFile
         TaskAction="ReadAttribute"
         File="$(_testResultFile)"
-        XPath="/test-results/@failures">
+        XPath="/test-run/@failed">
       <Output TaskParameter="Value" PropertyName="_nunit_failures" />
-    </MSBuild.ExtensionPack.Xml.XmlFile>
-
-    <MSBuild.ExtensionPack.Xml.XmlFile
-        TaskAction="ReadAttribute"
-        File="$(_testResultFile)"
-        XPath="/test-results/@errors">
-      <Output TaskParameter="Value" PropertyName="_nunit_errors" />
     </MSBuild.ExtensionPack.Xml.XmlFile>
 
     <MSBuild.ExtensionPack.Framework.TextString TaskAction="Replace" OldString="$(_testTime)" OldValue="." NewValue="">
@@ -226,55 +238,37 @@ $(_dockerImageName) $(_nunitCallArgumentString)
     <Message Text="##teamcity[buildStatisticValue key='$(_testName)' value='$(_testTime)']"
              Condition="'$(TEAMCITY_VERSION)' != ''"/>
 
-    <ItemGroup Condition="$(_nunit_failures) &gt; 0 or $(_nunit_errors) &gt; 0">
+    <ItemGroup Condition="$(_nunit_failures) &gt; 0">
       <NumberOfTestFailuresPerProject Include="$(_nunit_failures)"/>
-      <NumberOfTestErrorsPerProject Include="$(_nunit_errors)"/>
       <FailedProjects Include="$(_testAssemblyFullPath)">
         <Platform>$(_platform)</Platform>
         <DatabaseSystem>$(_databaseSystem)</DatabaseSystem>
         <Browser>$(_browser)</Browser>
         <Failures>$(_nunit_failures)</Failures>
-        <Errors>$(_nunit_errors)</Errors>
       </FailedProjects>
     </ItemGroup>
   </Target>
 
-  <!-- We need to configure Nunit differently to run it on a System with or without .Net 3.5 installed. Can be removed after the switch to Nunit 3-->
-  <Target Name="PrepareNunitDirectory" Outputs="%(_nunitDestinationFolderPath.Identity)">
+  <Target Name="PrepareNunitDirectory" Outputs="$(_nunitRunnerFolderPath)">
     <Error Text="The property 'TempDirectory' is not set." Condition="'$(TempDirectory)' == ''" />
     <Error Text="The property 'NUnitToolPath' is not set." Condition="'$(NUnitToolPath)' == ''" />
 
     <PropertyGroup>
-      <_dockerTempFolderName>$(TempDirectory)SharedSourceBuildNunitCopy\</_dockerTempFolderName>
-      <NunitFolderPathWithDefaultConfiguration>$(_dockerTempFolderName)NunitDefaultConfiguration\</NunitFolderPathWithDefaultConfiguration>
-      <NunitFolderPathWithoutDotNet35Dependency>$(_dockerTempFolderName)NunitWithoutDotNet35Dependency\</NunitFolderPathWithoutDotNet35Dependency>
+      <_nunitRunnerFolderPath>$(TempDirectory)SharedSourceBuildNunitCopy\</_nunitRunnerFolderPath>
     </PropertyGroup>
 
-    <ItemGroup>
-      <_nunitDestinationFolderPath Include="$(NunitFolderPathWithDefaultConfiguration)">
-        <SupportedRuntimeConfiguration></SupportedRuntimeConfiguration>
-      </_nunitDestinationFolderPath>
-
-      <_nunitDestinationFolderPath Include="$(NunitFolderPathWithoutDotNet35Dependency)">
-        <SupportedRuntimeConfiguration>&lt;supportedRuntime version=&quot;v4.0.30319&quot; /&gt;</SupportedRuntimeConfiguration>
-      </_nunitDestinationFolderPath>
-    </ItemGroup>
+    <WriteLinesToFile
+        File="$(NUnitToolPath)Remotion.NUnit.addins"
+        Lines="*.dll"
+        Overwrite="true"
+        Encoding="Unicode"/>
 
     <ItemGroup>
-      <_filesToBeCopied Include="$(NUnitToolPath)**\*.*"></_filesToBeCopied>
+      <_filesToBeCopied Include="$(NUnitToolPath)**\*.*" />
+      <_filesToBeCopied Include="%(NUnitExtensionsPaths.Identity)**\*.*" />
     </ItemGroup>
 
-    <Copy SourceFiles="@(_filesToBeCopied)" DestinationFolder="%(_nunitDestinationFolderPath.Identity)"></Copy>
-
-    <MSBuild.ExtensionPack.Xml.XmlFile TaskAction="UpdateElement"
-        File="%(_nunitDestinationFolderPath.Identity)nunit-console.exe.config"
-        XPath="configuration/startup"
-        InnerXml="$([MSBuild]::Unescape('%(_nunitDestinationFolderPath.SupportedRuntimeConfiguration)'))" />
-
-    <MSBuild.ExtensionPack.Xml.XmlFile TaskAction="UpdateElement"
-        File="%(_nunitDestinationFolderPath.Identity)nunit-console-x86.exe.config"
-        XPath="configuration/startup"
-        InnerXml="$([MSBuild]::Unescape('%(_nunitDestinationFolderPath.SupportedRuntimeConfiguration)'))" />
+    <Copy SourceFiles="@(_filesToBeCopied)" DestinationFolder="$(_nunitRunnerFolderPath)" />
   </Target>
 
   <Target Name="CreateTestConfigurations">

--- a/BuildScript/Main/Remotion.build
+++ b/BuildScript/Main/Remotion.build
@@ -25,7 +25,7 @@
     <ExtensionTasksPath>$(MSBuildExtensionPackPath)</ExtensionTasksPath>
     <DependDBBuildProcessorToolPath Condition="'$(NuGetToolPath)' == ''">$(PackagesDirectory)DependDB.BuildProcessor.2.0.0\tools\</DependDBBuildProcessorToolPath>
     <DependDBNuGetPreProcessorToolPath Condition="'$(NuGetToolPath)' == ''">$(PackagesDirectory)DependDB.BuildProcessor.NuGetPreProcessor.2.0.0\tools\</DependDBNuGetPreProcessorToolPath>
-    <NUnitToolPath Condition="'$(NUnitToolPath)' == ''">$(PackagesDirectory)NUnit.Runners.2.6.3\tools\</NUnitToolPath>
+    <NUnitToolPath Condition="'$(NUnitToolPath)' == ''">$(PackagesDirectory)NUnit.ConsoleRunner.3.11.1\tools\</NUnitToolPath>
     <NuGetToolPath Condition="'$(NuGetToolPath)' == ''">$(PackagesDirectory)NuGet.CommandLine.3.5.0\tools\</NuGetToolPath>
     <NuGetForMSBuildPath Condition="'$(NuGetForMSBuildPath)' == ''">$(PackagesDirectory)NuGet.for.MSBuild.1.4.3\build\</NuGetForMSBuildPath>
     <RemotionBuildTasksPath Condition="'$(RemotionBuildTasksPath)' == ''">$(PackagesDirectory)Remotion.BuildTools.MSBuildTasks.1.0.6862.28795\tools\</RemotionBuildTasksPath>


### PR DESCRIPTION
### Jira Issue
https://re-motion.atlassian.net/browse/RMSRCBUILD-115

### Breaking Changes

The NuGet package `NUnit.Runners` is not supported anymore. Use `NUnit.ConsoleRunner` instead for getting an NUnit executable. Additionally, running NUnit2 tests requires using the `NUnit.Extension.NUnitV2Driver` NuGet package and setting the MsBuild item `NUnitExtensionsPaths` to the package's root path (e.G. `<NUnitExtensionsPaths Include="$(PackagesDirectory)NUnit.Extension.NUnitV2Driver.3.8.0\"/>`). Running V3 tests while the V2 driver is enabled **is** possible.

Also, all `build.cmd` files need to be upgraded, as Nunit3 requires a newer version of nuget.exe which the hardcoded link inside the `build.cmd` files cannot deliver.

### How to test

It was not possible to provide automated tests, since all changes were MsBuild changes. The existing C# tests are all still green (duh). The easiest way to test this would be to use Remotion-IO and its branch `spike/nunit3` that I created. I personally used it to test everything. Running V2 tests on the re-motion trunk also worked as expected.

### Checklist

Since all changes are MsBuild changes, this checklist is almost completely useless. Nevertheless:

- [x] I have adapted schema files if I made changes to XML Config Files.
- [x] All new files have license headers.
- [x] All new public classes, methods and properties have XML documentation and JetBrains annotations.
- [x] I have identified all breaking changes and marked them appropriately.
- [x] I have followed the style guide to the best of my ability.
- [x] If I added new projects to the solution, I also added them to the corresponding `projects.props` file.

### Remarks

I used this opportunity to upgrade the existing C# tests to NUnit3.

