### PR TITLE
RMSRCBUILD-120: NUnit3 [OneTimeTeardown] errors are not being reported as test failures

### DIFF
--- a/BuildScript/BuildTargets/Testing.targets
+++ b/BuildScript/BuildTargets/Testing.targets
@@ -48,7 +48,11 @@
 
     <Error
       Text="Running Unit-Tests failed because of $(_failures) failures in: %0A@(FailedProjects->'%(Identity) (%(Platform)/%(DatabaseSystem)) with %(Failures) failures','%0A')"
-      Condition="$(_failures) &gt; 0"/>
+      Condition="$(_failures) &gt; 0 and '$(_nunitIsSuccess)' == 'False'"/>
+
+    <Error
+      Text="One or more test runs resulted in a failure, but the tests themselves have passed. This most likely means that a Setup, Teardown, OneTimeSetup or OneTimeTeardown method threw and exception. Check the log for more information. Failed test assemblies: %0A@(FailedProjects->'%(Identity)','%0A')"
+      Condition="$(_failures) == 0 and '$(_nunitIsSuccess)' == 'False'"/>
 
     <PropertyGroup>
       <_timeTaken>$([System.DateTime]::UtcNow.Subtract($([System.DateTime]::Parse($(RunTestsStartTime)))).TotalMilliseconds.ToString(0))</_timeTaken>
@@ -231,6 +235,13 @@ $(_dockerImageName) $(_nunitCallArgumentString)
       <Output TaskParameter="Value" PropertyName="_nunit_failures" />
     </MSBuild.ExtensionPack.Xml.XmlFile>
 
+    <MSBuild.ExtensionPack.Xml.XmlFile
+        TaskAction="ReadAttribute"
+        File="$(_testResultFile)"
+        XPath="/test-run/@result">
+      <Output TaskParameter="Value" PropertyName="_nunitResult" />
+    </MSBuild.ExtensionPack.Xml.XmlFile>
+
     <MSBuild.ExtensionPack.Framework.TextString TaskAction="Replace" OldString="$(_testTime)" OldValue="." NewValue="">
       <Output TaskParameter="NewString" PropertyName="_testTime" />
     </MSBuild.ExtensionPack.Framework.TextString>
@@ -238,7 +249,7 @@ $(_dockerImageName) $(_nunitCallArgumentString)
     <Message Text="##teamcity[buildStatisticValue key='$(_testName)' value='$(_testTime)']"
              Condition="'$(TEAMCITY_VERSION)' != ''"/>
 
-    <ItemGroup Condition="$(_nunit_failures) &gt; 0">
+    <ItemGroup Condition="'$(_nunitResult)' == 'Failed'">
       <NumberOfTestFailuresPerProject Include="$(_nunit_failures)"/>
       <FailedProjects Include="$(_testAssemblyFullPath)">
         <Platform>$(_platform)</Platform>
@@ -247,6 +258,10 @@ $(_dockerImageName) $(_nunitCallArgumentString)
         <Failures>$(_nunit_failures)</Failures>
       </FailedProjects>
     </ItemGroup>
+
+    <PropertyGroup>
+      <_nunitIsSuccess Condition="'$(_nunitResult)' == 'Failed'">False</_nunitIsSuccess>
+    </PropertyGroup>
   </Target>
 
   <Target Name="PrepareNunitDirectory" Outputs="$(_nunitRunnerFolderPath)">

--- a/BuildScript/BuildTargets/Testing.targets
+++ b/BuildScript/BuildTargets/Testing.targets
@@ -48,7 +48,7 @@
 
     <Error
       Text="Running Unit-Tests failed because of $(_failures) failures in: %0A@(FailedProjects->'%(Identity) (%(Platform)/%(DatabaseSystem)) with %(Failures) failures','%0A')"
-      Condition="$(_failures) &gt; 0 and '$(_nunitIsSuccess)' == 'False'"/>
+      Condition="$(_failures) &gt; 0"/>
 
     <Error
       Text="One or more test runs resulted in a failure, but the tests themselves have passed. This most likely means that a Setup, Teardown, OneTimeSetup or OneTimeTeardown method threw and exception. Check the log for more information. Failed test assemblies: %0A@(FailedProjects->'%(Identity)','%0A')"


### PR DESCRIPTION
Questions you may have:

**Are the tests that ran in a fixture with a failed [OneTimeTeardown] marked as failed?**
No, Teamcity does not show them as failed. NUnit does, however, print an error message with the csproj file containing the failed method, so identifying it is not hard. With this change, we now print out an extra error message and fail the build if such a method fails, and NUnit's error output is very close to our error message so it will be seen. Rider (and probably Resharper) DO mark the entire fixture as failed, so inside the IDE this was never a problem.

**What happens if we have "normal" assert failures and failing OneTimeTeardowns in a single build?**
The build will fail as expected, but the tests with the failing OneTimeTeardown won't be marked as failed either. The above mentioned NUnit error message WILL be present in the build log, but it might not be prominent. If these assert failures are fixed and another build is started, our new, prominent error message will be printed.

**Do [SetUp], [OneTimeSetUp] and [Teardown] cause the same problems?**
No, it seems that a test is only _not_ marked as failed if OneTimeTeardown failed. If any of the other methods fail, the tests were always marked as failed in my testings.