### PR TITLE
RMSRCBUILD-124: RunTestsInternal in Testing.targets tries to run tests even if no test configurations are available

### DIFF
--- a/BuildScript/BuildTargets/Testing.targets
+++ b/BuildScript/BuildTargets/Testing.targets
@@ -73,6 +73,7 @@
 
   <Target Name="RunTestsInternal"
           DependsOnTargets="AddAdditionalMetadataToOutputFiles;CreateTestConfigurations;PrepareNunitDirectory"
+          Inputs="%(_testOutputFiles.Identity)"
           Outputs="%(_testOutputFiles.Identity)">
     <Message Text="Running tests %(_testOutputFiles.Identity)" Importance="High"/>
 


### PR DESCRIPTION
https://re-motion.atlassian.net/browse/RMSRCBUILD-124