### PR TITLE
RMSRCBUILD-125: Expose DockerImage information with EnforcedLocalMachine Builds

### DIFF
--- a/BuildScript.UnitTests/MetadataValueDictionaryTest.cs
+++ b/BuildScript.UnitTests/MetadataValueDictionaryTest.cs
@@ -111,7 +111,7 @@ namespace Remotion.BuildScript.UnitTests
     [TestCase ("aaa", "ccc")]
     [TestCase ("AAA", "ccc")]
     [TestCase ("AaA", "cCc")]
-    public void GetAllMatches_IsCaseInsensitive (string searchKey1, string searchKey2)
+    public void Intersect_IsCaseInsensitive (string searchKey1, string searchKey2)
     {
       var rawCollection = new Dictionary<string, string> { { "AAA", "BBB" }, { "CCC", "DDD" } };
       var collection = new MetadataValueDictionary (rawCollection);

--- a/BuildScript.UnitTests/MetadataValueDictionaryTest.cs
+++ b/BuildScript.UnitTests/MetadataValueDictionaryTest.cs
@@ -117,7 +117,7 @@ namespace Remotion.BuildScript.UnitTests
       var collection = new MetadataValueDictionary (rawCollection);
       var searchKeys = new[] { searchKey1, searchKey2, "RegularSearchKey" };
 
-      var matches = collection.GetAllMatches (searchKeys).ToArray();
+      var matches = collection.Intersect (searchKeys).ToArray();
 
       Assert.That (matches[0].Key, Is.EqualTo ("AAA"));
       Assert.That (matches[0].Value, Is.EqualTo ("BBB"));

--- a/BuildScript.UnitTests/MetadataValueDictionaryTest.cs
+++ b/BuildScript.UnitTests/MetadataValueDictionaryTest.cs
@@ -16,6 +16,7 @@
 //
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using NUnit.Framework;
 using Remotion.BuildScript.BuildTasks;
 
@@ -103,6 +104,37 @@ namespace Remotion.BuildScript.UnitTests
       var result = collection.ContainsKey (searchKey);
 
       Assert.That (result, Is.True);
+    }
+
+    [Test]
+    [TestCase ("AAA", "CCC")]
+    [TestCase ("aaa", "ccc")]
+    [TestCase ("AAA", "ccc")]
+    [TestCase ("AaA", "cCc")]
+    public void GetAllMatches_IsCaseInsensitive (string searchKey1, string searchKey2)
+    {
+      var rawCollection = new Dictionary<string, string> { { "AAA", "BBB" }, { "CCC", "DDD" } };
+      var collection = new MetadataValueDictionary (rawCollection);
+      var searchKeys = new[] { searchKey1, searchKey2, "RegularSearchKey" };
+
+      var matches = collection.GetAllMatches (searchKeys, () => new Exception()).ToArray();
+
+      Assert.That (matches[0].Key, Is.EqualTo ("AAA"));
+      Assert.That (matches[0].Value, Is.EqualTo ("BBB"));
+      Assert.That (matches[1].Key, Is.EqualTo ("CCC"));
+      Assert.That (matches[1].Value, Is.EqualTo ("DDD"));
+    }
+
+    [Test]
+    public void GetAllMatches_DoesNotExist_ThrowsException ()
+    {
+      var rawCollection = new Dictionary<string, string> { { "AAA", "BBB" }, { "CCC", "DDD" } };
+      var collection = new MetadataValueDictionary (rawCollection);
+      var searchKeys = new[] { "SearchKey1", "SearchKey2" };
+
+      Assert.That (
+          () => collection.GetAllMatches (searchKeys, () => new Exception ("MyMessage")).ToArray(),
+          Throws.Exception.With.Message.EqualTo ("MyMessage"));
     }
   }
 }

--- a/BuildScript.UnitTests/MetadataValueDictionaryTest.cs
+++ b/BuildScript.UnitTests/MetadataValueDictionaryTest.cs
@@ -124,17 +124,5 @@ namespace Remotion.BuildScript.UnitTests
       Assert.That (matches[1].Key, Is.EqualTo ("CCC"));
       Assert.That (matches[1].Value, Is.EqualTo ("DDD"));
     }
-
-    [Test]
-    public void GetAllMatches_DoesNotExist_ThrowsException ()
-    {
-      var rawCollection = new Dictionary<string, string> { { "AAA", "BBB" }, { "CCC", "DDD" } };
-      var collection = new MetadataValueDictionary (rawCollection);
-      var searchKeys = new[] { "SearchKey1", "SearchKey2" };
-
-      Assert.That (
-          () => collection.GetAllMatches (searchKeys, () => new Exception ("MyMessage")).ToArray(),
-          Throws.Exception.With.Message.EqualTo ("MyMessage"));
-    }
   }
 }

--- a/BuildScript.UnitTests/MetadataValueDictionaryTest.cs
+++ b/BuildScript.UnitTests/MetadataValueDictionaryTest.cs
@@ -117,7 +117,7 @@ namespace Remotion.BuildScript.UnitTests
       var collection = new MetadataValueDictionary (rawCollection);
       var searchKeys = new[] { searchKey1, searchKey2, "RegularSearchKey" };
 
-      var matches = collection.GetAllMatches (searchKeys, () => new Exception()).ToArray();
+      var matches = collection.GetAllMatches (searchKeys).ToArray();
 
       Assert.That (matches[0].Key, Is.EqualTo ("AAA"));
       Assert.That (matches[0].Value, Is.EqualTo ("BBB"));

--- a/BuildScript.UnitTests/MetadataValueDictionaryTest.cs
+++ b/BuildScript.UnitTests/MetadataValueDictionaryTest.cs
@@ -116,13 +116,11 @@ namespace Remotion.BuildScript.UnitTests
       var rawCollection = new Dictionary<string, string> { { "AAA", "BBB" }, { "CCC", "DDD" } };
       var collection = new MetadataValueDictionary (rawCollection);
       var searchKeys = new[] { searchKey1, searchKey2, "RegularSearchKey" };
+      var expected = new[] { new KeyValuePair<string, string> ("AAA", "BBB"), new KeyValuePair<string, string> ("CCC", "DDD") };
 
-      var matches = collection.Intersect (searchKeys).ToArray();
+      var intersection = collection.Intersect (searchKeys).ToArray();
 
-      Assert.That (matches[0].Key, Is.EqualTo ("AAA"));
-      Assert.That (matches[0].Value, Is.EqualTo ("BBB"));
-      Assert.That (matches[1].Key, Is.EqualTo ("CCC"));
-      Assert.That (matches[1].Value, Is.EqualTo ("DDD"));
+      Assert.That (intersection, Is.EquivalentTo (expected));
     }
   }
 }

--- a/BuildScript.UnitTests/TestConfigurationsFactoryTest.cs
+++ b/BuildScript.UnitTests/TestConfigurationsFactoryTest.cs
@@ -605,6 +605,55 @@ namespace Remotion.BuildScript.UnitTests
           Is.EqualTo ("MyTest.dll+Chrome+SqlServer2014+x64+Win_NET46+NET45+release+IncludeCategories=a,b,c+ExcludeCategories=d,e"));
     }
 
+    [Test]
+    public void CreateTestConfigurations_EnforcedLocalMachine_CanBeExtraFlag ()
+    {
+      var factory = CreateTestConfigurationFactory (supportedExecutionRuntimes: new Dictionary<string, string>
+                                                                                {
+                                                                                    { "WIN_NET462", "DockerImageValue" },
+                                                                                    { "EnforcedLocalMachine", "EnforcedLocalMachine" }
+                                                                                });
+
+      var testConfigurations = factory.CreateTestConfigurations (
+          "C:\\Path\\To\\MyTest.dll",
+          new[] { "Chrome+SqlServer2014+x64+WIN_NET462+release+net45+EnforcedLocalMachine" });
+
+      Assert.That (testConfigurations.Single().ExecutionRuntime.UseDocker, Is.False);
+      Assert.That (testConfigurations.Single().ExecutionRuntime.Key, Is.EqualTo ("EnforcedLocalMachine"));
+      Assert.That (testConfigurations.Single().ExecutionRuntime.Value, Is.EqualTo ("EnforcedLocalMachine"));
+      Assert.That (testConfigurations.Single().ExecutionRuntime.DockerImage, Is.EqualTo ("DockerImageValue"));
+    }
+
+    [Test]
+    public void CreateTestConfigurations_ExecutionRuntimeWithDocker_ExposesAdditionalDockerImage ()
+    {
+      var factory = CreateTestConfigurationFactory (supportedExecutionRuntimes: new Dictionary<string, string> { { "Win_NET48", "DockerImageWinNet48" } });
+
+      var testConfigurations = factory.CreateTestConfigurations ("C:\\Path\\To\\MyTest.dll", new[] { "Chrome+SqlServer2014+x64+Win_NET48+release+net45" });
+
+      Assert.That (testConfigurations.Single().ExecutionRuntime.DockerImage, Is.EqualTo ("DockerImageWinNet48"));
+    }
+
+    [Test]
+    public void CreateTestConfigurations_LocalMachine_ExposesEmptyDockerImage ()
+    {
+      var factory = CreateTestConfigurationFactory (supportedExecutionRuntimes: new Dictionary<string, string> { { "LocalMachine", "LocalMachine" } });
+
+      var testConfigurations = factory.CreateTestConfigurations ("C:\\Path\\To\\MyTest.dll", new[] { "Chrome+SqlServer2014+x64+LocalMachine+release+net45" });
+
+      Assert.That (testConfigurations.Single().ExecutionRuntime.DockerImage, Is.EqualTo (""));
+    }
+
+    [Test]
+    public void CreateTestConfigurations_EnforcedLocalMachine_ExposesEmptyDockerImage ()
+    {
+      var factory = CreateTestConfigurationFactory (supportedExecutionRuntimes: new Dictionary<string, string> { { "EnforcedLocalMachine", "EnforcedLocalMachine" } });
+
+      var testConfigurations = factory.CreateTestConfigurations ("C:\\Path\\To\\MyTest.dll", new[] { "Chrome+SqlServer2014+x64+EnforcedLocalMachine+release+net45" });
+
+      Assert.That (testConfigurations.Single().ExecutionRuntime.DockerImage, Is.EqualTo (""));
+    }
+
     private TestConfigurationsFactory CreateTestConfigurationFactory (
         IReadOnlyCollection<string> supportedPlatforms = null,
         IReadOnlyCollection<string> supportedDatabaseSystems = null,

--- a/BuildScript.UnitTests/TestConfigurationsFactoryTest.cs
+++ b/BuildScript.UnitTests/TestConfigurationsFactoryTest.cs
@@ -608,11 +608,12 @@ namespace Remotion.BuildScript.UnitTests
     [Test]
     public void CreateTestConfigurations_EnforcedLocalMachine_CanBeExtraFlag ()
     {
-      var factory = CreateTestConfigurationFactory (supportedExecutionRuntimes: new Dictionary<string, string>
-                                                                                {
-                                                                                    { "WIN_NET462", "DockerImageValue" },
-                                                                                    { "EnforcedLocalMachine", "EnforcedLocalMachine" }
-                                                                                });
+      var factory = CreateTestConfigurationFactory (
+          supportedExecutionRuntimes: new Dictionary<string, string>
+                                      {
+                                          { "WIN_NET462", "DockerImageValue" },
+                                          { "EnforcedLocalMachine", "EnforcedLocalMachine" }
+                                      });
 
       var testConfigurations = factory.CreateTestConfigurations (
           "C:\\Path\\To\\MyTest.dll",
@@ -667,6 +668,22 @@ namespace Remotion.BuildScript.UnitTests
       Assert.That (
           () => factory.CreateTestConfigurations ("C:\\Path\\To\\MyTest.dll", new[] { "Chrome+SqlServer2014+x64+Win_NET472+Win_NET48+release+net45" }),
           Throws.InvalidOperationException.With.Message.EqualTo ("Found multiple execution runtimes: Win_NET472,Win_NET48")
+          );
+    }
+
+    [Test]
+    public void CreateTestConfigurations_MultipleLocalExecutionRuntimes_ThrowsException ()
+    {
+      var factory = CreateTestConfigurationFactory (
+          supportedExecutionRuntimes: new Dictionary<string, string>
+                                      {
+                                          { MetadataValueConstants.LocalMachine, MetadataValueConstants.LocalMachine },
+                                          { MetadataValueConstants.EnforcedLocalMachine, MetadataValueConstants.EnforcedLocalMachine }
+                                      });
+
+      Assert.That (
+          () => factory.CreateTestConfigurations ("C:\\Path\\To\\MyTest.dll", new[] { "Chrome+SqlServer2014+x64+LocalMachine+EnforcedLocalMachine+release+net45" }),
+          Throws.InvalidOperationException.With.Message.EqualTo ("Found multiple execution runtimes: LocalMachine,EnforcedLocalMachine")
           );
     }
 

--- a/BuildScript.UnitTests/TestConfigurationsFactoryTest.cs
+++ b/BuildScript.UnitTests/TestConfigurationsFactoryTest.cs
@@ -654,6 +654,22 @@ namespace Remotion.BuildScript.UnitTests
       Assert.That (testConfigurations.Single().ExecutionRuntime.DockerImage, Is.EqualTo (""));
     }
 
+    [Test]
+    public void CreateTestConfigurations_MultipleExecutionRuntimes_ThrowsException ()
+    {
+      var factory = CreateTestConfigurationFactory (
+          supportedExecutionRuntimes: new Dictionary<string, string>
+                                      {
+                                          { "Win_NET472", "DockerNet472" },
+                                          { "Win_NET48", "DockerNet48" }
+                                      });
+
+      Assert.That (
+          () => factory.CreateTestConfigurations ("C:\\Path\\To\\MyTest.dll", new[] { "Chrome+SqlServer2014+x64+Win_NET472+Win_NET48+release+net45" }),
+          Throws.InvalidOperationException.With.Message.EqualTo ("Found multiple execution runtimes: Win_NET472,Win_NET48")
+          );
+    }
+
     private TestConfigurationsFactory CreateTestConfigurationFactory (
         IReadOnlyCollection<string> supportedPlatforms = null,
         IReadOnlyCollection<string> supportedDatabaseSystems = null,

--- a/BuildScript.UnitTests/TestConfigurationsFilterTest.cs
+++ b/BuildScript.UnitTests/TestConfigurationsFilterTest.cs
@@ -403,7 +403,11 @@ namespace Remotion.BuildScript.UnitTests
           configurationID ?? "debug",
           false,
           platform ?? "x64",
-          new ExecutionRuntime (executionRuntimeKey ?? "Win_NET45", executionRuntimeValue ?? "DockerImageForWinNET45", true),
+          new ExecutionRuntime (
+              executionRuntimeKey ?? "Win_NET45",
+              executionRuntimeValue ?? "DockerImageForWinNET45",
+              true,
+              executionRuntimeValue ?? "DockerImageForWinNET45"),
           "TestAssembly.dll",
           testAssemblyFullPath ?? "C:\\Path\\To\\TestAssembly.dll''",
           "DirectoryFileName",

--- a/BuildScript/BuildScript.csproj
+++ b/BuildScript/BuildScript.csproj
@@ -123,6 +123,7 @@
     <Compile Include="BuildTasks\TestConfigurationsFilter.cs" />
     <Compile Include="BuildTasks\TestConfigurationMetadata.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="StringKeyValuePairListExtensions.cs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="JetBrains.Annotations, Version=2019.1.3.0, Culture=neutral, PublicKeyToken=1010a0d8d6380325">

--- a/BuildScript/BuildTargets/Testing.targets
+++ b/BuildScript/BuildTargets/Testing.targets
@@ -92,7 +92,7 @@
       <_testAssemblyFullPath>%(_testOutputFiles.TestAssemblyFullPath)</_testAssemblyFullPath>
       <_testAssemblyDirectory>%(_testOutputFiles.TestAssemblyDirectoryName)</_testAssemblyDirectory>
       <_use32Bit>%(_testOutputFiles.Use32Bit)</_use32Bit>
-      <_dockerImageName>%(_testOutputFiles.ExecutionRuntimeValue)</_dockerImageName>
+      <_dockerImageName>%(_testOutputFiles.DockerImage)</_dockerImageName>
       <_executionRuntimeKey>%(_testOutputFiles.ExecutionRuntimeKey)</_executionRuntimeKey>
       <_targetRuntime>%(_testOutputFiles.TargetRuntime)</_targetRuntime>
       <_platform>%(_testOutputFiles.Platform)</_platform>
@@ -115,7 +115,8 @@
                 Platform=$(_platform);
                 AppConfigFile=$(_appConfigFile);
                 DatabaseSystem=$(_databaseSystem);
-                Browser=$(_browser);"
+                Browser=$(_browser);
+                DockerImage=$(_dockerImageName);"
              Condition="'$(_testingSetupBuildFile)' != ''"/>
 
     <!-- Run tests -->

--- a/BuildScript/BuildTasks/CreateTestConfigurations.cs
+++ b/BuildScript/BuildTasks/CreateTestConfigurations.cs
@@ -161,6 +161,7 @@ namespace Remotion.BuildScript.BuildTasks
       item.SetMetadata (TestConfigurationMetadata.Platform, testConfiguration.Platform);
       item.SetMetadata (TestConfigurationMetadata.ExecutionRuntimeValue, testConfiguration.ExecutionRuntime.Value);
       item.SetMetadata (TestConfigurationMetadata.ExecutionRuntimeKey, testConfiguration.ExecutionRuntime.Key);
+      item.SetMetadata (TestConfigurationMetadata.DockerImage, testConfiguration.ExecutionRuntime.DockerImage);
       item.SetMetadata (TestConfigurationMetadata.TargetRuntime, testConfiguration.TargetRuntime);
       item.SetMetadata (TestConfigurationMetadata.Use32Bit, testConfiguration.Use32Bit.ToString());
       item.SetMetadata (TestConfigurationMetadata.UseDocker, testConfiguration.ExecutionRuntime.UseDocker.ToString());

--- a/BuildScript/BuildTasks/ExecutionRuntime.cs
+++ b/BuildScript/BuildTasks/ExecutionRuntime.cs
@@ -25,7 +25,6 @@ namespace Remotion.BuildScript.BuildTasks
     public string Value { get; }
     public string DockerImage { get; }
 
-
     public ExecutionRuntime (string key, string value, bool useDocker, string dockerImage)
     {
       Key = key;

--- a/BuildScript/BuildTasks/ExecutionRuntime.cs
+++ b/BuildScript/BuildTasks/ExecutionRuntime.cs
@@ -23,12 +23,15 @@ namespace Remotion.BuildScript.BuildTasks
     public bool UseDocker { get; }
     public string Key { get; }
     public string Value { get; }
+    public string DockerImage { get; }
 
-    public ExecutionRuntime (string key, string value, bool useDocker)
+
+    public ExecutionRuntime (string key, string value, bool useDocker, string dockerImage)
     {
       Key = key;
       Value = value;
       UseDocker = useDocker;
+      DockerImage = dockerImage;
     }
   }
 }

--- a/BuildScript/BuildTasks/ExecutionRuntime.cs
+++ b/BuildScript/BuildTasks/ExecutionRuntime.cs
@@ -32,5 +32,13 @@ namespace Remotion.BuildScript.BuildTasks
       UseDocker = useDocker;
       DockerImage = dockerImage;
     }
+
+    public ExecutionRuntime (string sameKeyAndValue, bool useDocker, string dockerImage)
+    {
+      Key = sameKeyAndValue;
+      Value = sameKeyAndValue;
+      UseDocker = useDocker;
+      DockerImage = dockerImage;
+    }
   }
 }

--- a/BuildScript/BuildTasks/ExecutionRuntime.cs
+++ b/BuildScript/BuildTasks/ExecutionRuntime.cs
@@ -32,13 +32,5 @@ namespace Remotion.BuildScript.BuildTasks
       UseDocker = useDocker;
       DockerImage = dockerImage;
     }
-
-    public ExecutionRuntime (string sameKeyAndValue, bool useDocker, string dockerImage)
-    {
-      Key = sameKeyAndValue;
-      Value = sameKeyAndValue;
-      UseDocker = useDocker;
-      DockerImage = dockerImage;
-    }
   }
 }

--- a/BuildScript/BuildTasks/MetadataValueDictionary.cs
+++ b/BuildScript/BuildTasks/MetadataValueDictionary.cs
@@ -74,15 +74,8 @@ namespace Remotion.BuildScript.BuildTasks
 
       var intersection = _rawDictionary.Keys.Intersect (enumeratedPossibleKeys, _dictionaryStringComparer).ToArray();
 
-      if (intersection.Length == 0)
-      {
-        throw createEmptySequenceException();
-      }
-      else
-      {
-        foreach (var key in intersection)
-          yield return new KeyValuePair<string, string> (key, _rawDictionary[key]);
-      }
+      foreach (var key in intersection)
+        yield return new KeyValuePair<string, string> (key, _rawDictionary[key]);
     }
   }
 }

--- a/BuildScript/BuildTasks/MetadataValueDictionary.cs
+++ b/BuildScript/BuildTasks/MetadataValueDictionary.cs
@@ -72,10 +72,9 @@ namespace Remotion.BuildScript.BuildTasks
     {
       var enumeratedPossibleKeys = possibleKeys.ToArray();
 
-      var intersection = _rawDictionary.Keys.Intersect (enumeratedPossibleKeys, _dictionaryStringComparer).ToArray();
-
-      foreach (var key in intersection)
-        yield return new KeyValuePair<string, string> (key, _rawDictionary[key]);
+      return _rawDictionary.Keys
+          .Intersect (enumeratedPossibleKeys, _dictionaryStringComparer)
+          .Select (key => new KeyValuePair<string, string> (key, _rawDictionary[key]));
     }
   }
 }

--- a/BuildScript/BuildTasks/MetadataValueDictionary.cs
+++ b/BuildScript/BuildTasks/MetadataValueDictionary.cs
@@ -68,7 +68,7 @@ namespace Remotion.BuildScript.BuildTasks
       return _rawDictionary.ContainsKey (key);
     }
 
-    public IEnumerable<KeyValuePair<string, string>> GetAllMatches (IEnumerable<string> possibleKeys, Func<Exception> createEmptySequenceException)
+    public IEnumerable<KeyValuePair<string, string>> GetAllMatches (IEnumerable<string> possibleKeys)
     {
       var enumeratedPossibleKeys = possibleKeys.ToArray();
 

--- a/BuildScript/BuildTasks/MetadataValueDictionary.cs
+++ b/BuildScript/BuildTasks/MetadataValueDictionary.cs
@@ -67,5 +67,22 @@ namespace Remotion.BuildScript.BuildTasks
     {
       return _rawDictionary.ContainsKey (key);
     }
+
+    public IEnumerable<KeyValuePair<string, string>> GetAllMatches (IEnumerable<string> possibleKeys, Func<Exception> createEmptySequenceException)
+    {
+      var enumeratedPossibleKeys = possibleKeys.ToArray();
+
+      var intersection = _rawDictionary.Keys.Intersect (enumeratedPossibleKeys, _dictionaryStringComparer).ToArray();
+
+      if (intersection.Length == 0)
+      {
+        throw createEmptySequenceException();
+      }
+      else
+      {
+        foreach (var key in intersection)
+          yield return new KeyValuePair<string, string> (key, _rawDictionary[key]);
+      }
+    }
   }
 }

--- a/BuildScript/BuildTasks/MetadataValueDictionary.cs
+++ b/BuildScript/BuildTasks/MetadataValueDictionary.cs
@@ -68,7 +68,7 @@ namespace Remotion.BuildScript.BuildTasks
       return _rawDictionary.ContainsKey (key);
     }
 
-    public IEnumerable<KeyValuePair<string, string>> GetAllMatches (IEnumerable<string> possibleKeys)
+    public IEnumerable<KeyValuePair<string, string>> Intersect (IEnumerable<string> possibleKeys)
     {
       var enumeratedPossibleKeys = possibleKeys.ToArray();
 

--- a/BuildScript/BuildTasks/TestConfigurationMetadata.cs
+++ b/BuildScript/BuildTasks/TestConfigurationMetadata.cs
@@ -29,6 +29,7 @@ namespace Remotion.BuildScript.BuildTasks
     public const string Platform = "Platform";
     public const string ExecutionRuntimeValue = "ExecutionRuntimeValue";
     public const string ExecutionRuntimeKey = "ExecutionRuntimeKey";
+    public const string DockerImage = "DockerImage";
     public const string IsWebTest = "IsWebTest";
     public const string IsDatabaseTest = "IsDatabaseTest";
     public const string Use32Bit = "Use32Bit";

--- a/BuildScript/BuildTasks/TestConfigurationsFactory.cs
+++ b/BuildScript/BuildTasks/TestConfigurationsFactory.cs
@@ -139,19 +139,19 @@ namespace Remotion.BuildScript.BuildTasks
     private ExecutionRuntime GetExecutionRuntime (IEnumerable<string> configurationItems)
     {
       var enumeratedConfigurationItems = configurationItems.ToArray();
-      var intersection = _supportedExecutionRuntimes.Intersect (enumeratedConfigurationItems).ToArray();
+      var possibleExecutionRuntimes = _supportedExecutionRuntimes.Intersect (enumeratedConfigurationItems).ToArray();
 
-      if (intersection.Length == 0)
+      if (possibleExecutionRuntimes.Length == 0)
       {
         throw CreateMissingConfigurationItemException ("execution runtime");
       }
-      else if (intersection.Length == 1)
+      else if (possibleExecutionRuntimes.Length == 1)
       {
-        return CreateExecutionRuntimeFromSingle (intersection.Single());
+        return CreateExecutionRuntimeFromSingle (possibleExecutionRuntimes.Single());
       }
       else
       {
-        return CreateExecutionRuntimeFromMultiple (intersection, enumeratedConfigurationItems);
+        return CreateExecutionRuntimeFromMultiple (possibleExecutionRuntimes, enumeratedConfigurationItems);
       }
     }
 

--- a/BuildScript/BuildTasks/TestConfigurationsFactory.cs
+++ b/BuildScript/BuildTasks/TestConfigurationsFactory.cs
@@ -163,10 +163,7 @@ namespace Remotion.BuildScript.BuildTasks
       dockerImage = null;
       var enumeratedConfigurationItems = configurationItems.ToArray();
 
-      var possibleExecutionRuntimes = _supportedExecutionRuntimes.GetAllMatches (
-              enumeratedConfigurationItems,
-              () => CreateMissingConfigurationItemException ("execution runtime"))
-          .ToArray();
+      var possibleExecutionRuntimes = _supportedExecutionRuntimes.GetAllMatches (enumeratedConfigurationItems).ToArray();
 
       if (possibleExecutionRuntimes.Length == 1)
         return false;

--- a/BuildScript/BuildTasks/TestConfigurationsFactory.cs
+++ b/BuildScript/BuildTasks/TestConfigurationsFactory.cs
@@ -159,9 +159,9 @@ namespace Remotion.BuildScript.BuildTasks
       var dockerImage = possibleExecutionRuntimes.SingleOrDefault();
 
       if (hasLocalMachine)
-        return new ExecutionRuntime (MetadataValueConstants.LocalMachine, false, "");
+        return new ExecutionRuntime (MetadataValueConstants.LocalMachine, MetadataValueConstants.LocalMachine, false, "");
       else if (hasEnforcedLocalMachine)
-        return new ExecutionRuntime (MetadataValueConstants.EnforcedLocalMachine, false, dockerImage.Value ?? "");
+        return new ExecutionRuntime (MetadataValueConstants.EnforcedLocalMachine, MetadataValueConstants.EnforcedLocalMachine,false, dockerImage.Value ?? "");
       else
         return new ExecutionRuntime (dockerImage.Key, dockerImage.Value, true, dockerImage.Value);
     }

--- a/BuildScript/BuildTasks/TestConfigurationsFactory.cs
+++ b/BuildScript/BuildTasks/TestConfigurationsFactory.cs
@@ -163,7 +163,7 @@ namespace Remotion.BuildScript.BuildTasks
       dockerImage = null;
       var enumeratedConfigurationItems = configurationItems.ToArray();
 
-      var possibleExecutionRuntimes = _supportedExecutionRuntimes.GetAllMatches (enumeratedConfigurationItems).ToArray();
+      var possibleExecutionRuntimes = _supportedExecutionRuntimes.Intersect (enumeratedConfigurationItems).ToArray();
 
       if (possibleExecutionRuntimes.Length == 1)
         return false;

--- a/BuildScript/BuildTasks/TestConfigurationsFactory.cs
+++ b/BuildScript/BuildTasks/TestConfigurationsFactory.cs
@@ -145,7 +145,7 @@ namespace Remotion.BuildScript.BuildTasks
     private ExecutionRuntime GetExecutionRuntime (IEnumerable<string> configurationItems)
     {
       var enumeratedConfigurationItems = configurationItems.ToArray();
-      if (IsEnforcedLocalMachineAndHasDockerImage (enumeratedConfigurationItems, out var dockerImageOfEnforcedLocalMachine))
+      if (TryGetDockerImageIfIsEnforcedLocalMachine (enumeratedConfigurationItems, out var dockerImageOfEnforcedLocalMachine))
       {
         return new ExecutionRuntime (MetadataValueConstants.EnforcedLocalMachine, MetadataValueConstants.EnforcedLocalMachine, false, dockerImageOfEnforcedLocalMachine);
       }
@@ -158,7 +158,7 @@ namespace Remotion.BuildScript.BuildTasks
       return new ExecutionRuntime (kvp.Key, kvp.Value, shouldUseDocker, dockerImage);
     }
 
-    private bool IsEnforcedLocalMachineAndHasDockerImage (IEnumerable<string> configurationItems, out string dockerImage)
+    private bool TryGetDockerImageIfIsEnforcedLocalMachine (IEnumerable<string> configurationItems, out string dockerImage)
     {
       dockerImage = null;
       var enumeratedConfigurationItems = configurationItems.ToArray();

--- a/BuildScript/BuildTasks/TestConfigurationsFactory.cs
+++ b/BuildScript/BuildTasks/TestConfigurationsFactory.cs
@@ -142,17 +142,11 @@ namespace Remotion.BuildScript.BuildTasks
       var possibleExecutionRuntimes = _supportedExecutionRuntimes.Intersect (enumeratedConfigurationItems).ToArray();
 
       if (possibleExecutionRuntimes.Length == 0)
-      {
         throw CreateMissingConfigurationItemException ("execution runtime");
-      }
       else if (possibleExecutionRuntimes.Length == 1)
-      {
         return CreateExecutionRuntimeFromSingle (possibleExecutionRuntimes.Single());
-      }
       else
-      {
         return CreateExecutionRuntimeFromMultiple (possibleExecutionRuntimes, enumeratedConfigurationItems);
-      }
     }
 
     private ExecutionRuntime CreateExecutionRuntimeFromSingle (KeyValuePair<string, string> keyValuePair)

--- a/BuildScript/StringKeyValuePairListExtensions.cs
+++ b/BuildScript/StringKeyValuePairListExtensions.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+
+namespace Remotion.BuildScript
+{
+  public static class StringKeyValuePairListExtensions
+  {
+    public static bool Remove (this IList<KeyValuePair<string, string>> list, string sameKeyValue)
+    {
+      return list.Remove (new KeyValuePair<string, string> (sameKeyValue, sameKeyValue));
+    }
+  }
+}


### PR DESCRIPTION
https://re-motion.atlassian.net/browse/RMSRCBUILD-125

These changes are meant to be entirely additive, test configurations can still enforce running on local machines without exposing a docker image. The Remotion trunk web test configurations would look like this:

```
Chrome           + NET462 + Debug   + x86 + NoDB + Win_NET48  + EnforcedLocalMachine;
Firefox          + NET462 + Release + x64 + NoDB + Win_NET472 + EnforcedLocalMachine
InternetExplorer + NET462 + Release + x64 + NoDB + Win_NET48  + EnforcedLocalMachine;
Edge             + NET462 + Release + x64 + NoDB + Win_NET48  + EnforcedLocalMachine;
```