### PR TITLE
RMSRCBUILD-140 Build script helper function Parse-Version-From-ReleaseBranch incorrectly splits strings

### DIFF
--- a/ReleaseProcessScript/tools/Core/main_helper_functions.ps1
+++ b/ReleaseProcessScript/tools/Core/main_helper_functions.ps1
@@ -1,6 +1,6 @@
 function Parse-Version-From-ReleaseBranch ($Branchname)
 {
-  $SplitBranchname = $Branchname.Split("/v")
+  $SplitBranchname = $Branchname.Split(@("/v"), [System.StringSplitOptions]::None)
 
   if ($SplitBranchname.Length -ne 2)
   {

--- a/ReleaseProcessScript/tools/PesterTester/main_helper_functions.Tests.ps1
+++ b/ReleaseProcessScript/tools/PesterTester/main_helper_functions.Tests.ps1
@@ -1,0 +1,10 @@
+. $PSScriptRoot"\..\Core\main_helper_functions.ps1"
+
+Describe "main_helper_functions" {
+    Context "Parse-Version-From-ReleaseBranch" {
+        It "should split branch names correctly" {
+            $Version = "1.2.3"
+            Parse-Version-From-ReleaseBranch "release/v${Version}" | Should Be $Version
+        }
+    }
+}


### PR DESCRIPTION
https://re-motion.atlassian.net/browse/RMSRCBUILD-140