### PR TITLE
bug/RMSRCBUILD-285 DoesNotMergeIntoDevelopTest fails because of test setup

### DIFF
--- a/ReleaseProcessAutomation.Tests/Steps/Continues/ContinueReleaseOnMasterStepTests.cs
+++ b/ReleaseProcessAutomation.Tests/Steps/Continues/ContinueReleaseOnMasterStepTests.cs
@@ -143,9 +143,9 @@ internal class ContinueReleaseOnMasterStepTests
     );
 
     Assert.That(() => step.Execute(version, false), Throws.Nothing);
-    
-    gitClientMock.Verify(_ => _.MergeBranch("master", It.IsAny<bool>()), Times.Once);
-    gitClientMock.Verify(_ => _.MergeBranch("develop", It.IsAny<bool>()), Times.Never);
+
+    //must merge into master, therefore if only called once it only merged into master, not into develop
+    gitClientMock.Verify(_ => _.MergeBranch("release/v1.0.0", It.IsAny<bool>()), Times.Once);
     _nextReleaseStepMock.Verify(_=>_.Execute(It.IsAny<SemanticVersion>()), Times.Once);
   }
 


### PR DESCRIPTION
This is something where we tried to improve readability, but as merge branch calls which branch should be merged into the current branch, the old version failed. 

Is there some way we can test that a specific method call was made before the current one? In that case we could check that the correct branch is checked out before merging, therefore showing the result properly again and not allowing any tests to pass that shouldnt.